### PR TITLE
修复代币查询和余额显示问题

### DIFF
--- a/frontend/src/components/TokenQuery.vue
+++ b/frontend/src/components/TokenQuery.vue
@@ -324,7 +324,10 @@ export default {
     
     formatTokenBalance(balance, decimals) {
       if (balance === null || balance === undefined) return '0'
-      return (balance / Math.pow(10, decimals)).toFixed(6)
+      const fractionDigits = Math.min(Number(decimals) || 6, 8)
+      const num = typeof balance === 'string' ? Number(balance) : balance
+      if (!Number.isFinite(num)) return '0'
+      return num.toFixed(fractionDigits)
     },
     
     getNetworkName(chainId) {


### PR DESCRIPTION
Fix token name/symbol display and balance formatting.

Updates ABI decoding in `metamask.js` to correctly parse token names/symbols (bytes32/string), and adjusts `TokenQuery.vue` to prevent double division of token balances by `10^decimals`.

---
<a href="https://cursor.com/background-agent?bcId=bc-64cd6006-48af-49b6-9c53-d9491b8c8d21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64cd6006-48af-49b6-9c53-d9491b8c8d21">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

